### PR TITLE
Spelling mistake in aria role

### DIFF
--- a/templates/fieldable-panels-panes--hot-primary-tout.tpl.php
+++ b/templates/fieldable-panels-panes--hot-primary-tout.tpl.php
@@ -26,7 +26,7 @@ if( isset($content['field_hot_primary_tout_caption'] )){
 <?php if ($pane_prefix): ?>
   <?php print $pane_prefix; ?>
 <?php endif; ?>
-<aside class="<?php print $classes; ?>" <?php print $id; ?> <?php print $attributes; ?> role="complemtary">
+<aside class="<?php print $classes; ?>" <?php print $id; ?> <?php print $attributes; ?> role="complementary">
   <?php if ($admin_links): ?>
     <?php print $admin_links; ?>
   <?php endif; ?>


### PR DESCRIPTION
This failed an accessibility audit on a project because of the spelling mistake.
